### PR TITLE
doryd: don't allow cloneOf/cloneOfPVC requests with different size th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# OSX fun
+.DS_Store
+
+# build directory 
+build/
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+


### PR DESCRIPTION
…an parent

* Problem:
 * PVC can be created with size X using cloneOf/cloneOfPVC, while parent volume is of size Y
* Implementation:
 * check the size of parent volume during clone requests and error out if there is a mismatch
* Testing: tested with correct and mismatch sizes.
* Review: gcostea, sbyadarahalli
* Bug: https://nimblejira.nimblestorage.com/browse/CON-492