### PR TITLE
doryd: fix partial match of overridden param name with sc param

### DIFF
--- a/pkg/provisioner/claim.go
+++ b/pkg/provisioner/claim.go
@@ -78,8 +78,8 @@ func (p *Provisioner) processAddedClaim(claim *api_v1.PersistentVolumeClaim) {
 		log.Errorf("error getting class named %s for pvc %s. err=%v", className, claim.Name, err)
 		return
 	}
-	if !strings.HasPrefix(class.Provisioner, FlexVolumeProvisioner) {
-		log.Infof("class named %s in pvc %s did not refer to a supported provisioner (name must begin with %s).  current provisioner=%s - skipping", className, claim.Name, FlexVolumeProvisioner, class.Provisioner)
+	if !strings.HasPrefix(class.Provisioner, FlexVolumeProvisionerPrefix) {
+		log.Infof("class named %s in pvc %s did not refer to a supported provisioner (name must begin with %s).  current provisioner=%s - skipping", className, claim.Name, FlexVolumeProvisionerPrefix, class.Provisioner)
 		return
 	}
 
@@ -161,7 +161,7 @@ func (p *Provisioner) getClaimOverrideOptions(claim *api_v1.PersistentVolumeClai
 	provisionerName := provisioner
 	for _, override := range overrides {
 		for key, annotation := range claim.Annotations {
-			if strings.HasPrefix(strings.ToLower(key), provisionerName+"/"+strings.ToLower(override)) {
+			if strings.EqualFold(key, provisionerName+"/"+override) {
 				if valOpt, ok := optionsMap[override]; ok {
 					if override == "size" || override == "sizeInGiB" {
 						// do not allow  override of size and sizeInGiB

--- a/pkg/provisioner/volume.go
+++ b/pkg/provisioner/volume.go
@@ -120,7 +120,7 @@ func (p *Provisioner) processVolEvent(event string, vol *api_v1.PersistentVolume
 		return
 	}
 
-	if !strings.HasPrefix(vol.Annotations[k8sProvisionedBy], FlexVolumeProvisioner) {
+	if !strings.HasPrefix(vol.Annotations[k8sProvisionedBy], FlexVolumeProvisionerPrefix) {
 		log.Infof("%s event: pv:%s phase:%v (reclaim policy:%v) provisioner:%v - unknown provisioner skipping", event, vol.Name, vol.Status.Phase, vol.Spec.PersistentVolumeReclaimPolicy, vol.Annotations[k8sProvisionedBy])
 		return
 	}


### PR DESCRIPTION
* Problem:
  * allow overrides params are partially compared with PVC annotated params, causing
  * duplicate entries to be added to create request options.
  * due to this, importVol, importVolAsClone both were added.
* Implementation:
  * Fix by checking for exact match with override params and PVC param names.
  * during importVol also update SC param options with "name" as this is used
  * for flexVolSpec of PV and GET requests by dory.
* Testing: pvc with importVol, importVolAsClone, pod create/delete on Azure
* Review: gcostea, rkumar, sbyadarahalli
* Bug: https://nimblejira.nimblestorage.com/browse/CON-517
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>